### PR TITLE
Bug in DS in renaming boolean columns

### DIFF
--- a/crowdkit/aggregation/classification/dawid_skene.py
+++ b/crowdkit/aggregation/classification/dawid_skene.py
@@ -138,7 +138,7 @@ class DawidSkene(BaseClassificationAggregator):
         joined.loc[:, priors.index] = joined.loc[:, priors.index].add(np.log(priors))
 
         joined.set_index(['task', 'worker'], inplace=True)
-        joint_expectation = (probas * joined).sum().sum()
+        joint_expectation = (probas.rename(columns={True: 'True', False: 'False'} * joined).sum().sum()
 
         entropy = -(np.log(probas) * probas).sum().sum()
         return float(joint_expectation + entropy)

--- a/crowdkit/aggregation/classification/dawid_skene.py
+++ b/crowdkit/aggregation/classification/dawid_skene.py
@@ -138,7 +138,7 @@ class DawidSkene(BaseClassificationAggregator):
         joined.loc[:, priors.index] = joined.loc[:, priors.index].add(np.log(priors))
 
         joined.set_index(['task', 'worker'], inplace=True)
-        joint_expectation = (probas.rename(columns={True: 'True', False: 'False'} * joined).sum().sum()
+        joint_expectation = (probas.rename(columns={True: 'True', False: 'False'}) * joined).sum().sum()
 
         entropy = -(np.log(probas) * probas).sum().sum()
         return float(joint_expectation + entropy)


### PR DESCRIPTION
When labels are int(0) and int(1), they are renamed to 'True' and 'False' in `joined` but columns in `probas` are the same. It leads to nan's after multiplication and wrong ELBO result.

## Description


### Connected issues (if any)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation and examples improvement (changes affected documentation and/or examples)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
