### PR TITLE
Do not import TextSummarization if PyTorch is not installed

### DIFF
--- a/crowdkit/aggregation/__init__.py
+++ b/crowdkit/aggregation/__init__.py
@@ -1,4 +1,5 @@
 from typing import cast
+import importlib.util
 
 from . import base
 from .classification import (
@@ -71,5 +72,5 @@ def is_arcadia() -> bool:
         return False
 
 
-if not is_arcadia():
+if not is_arcadia() and importlib.util.find_spec('torch'):
     from .texts.text_summarization import TextSummarization


### PR DESCRIPTION
If PyTorch or TF is not installed, `transformers` throws out a warning produced with `logger.warning` that we can't filter. I propose to import `TextSummarization` only if PyTorch is installed. Otherwise, it's still not possible to use this method.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
