### PR TITLE
Fix relevance tests

### DIFF
--- a/tests/aggregation/test_binary_relevance_aggregation.py
+++ b/tests/aggregation/test_binary_relevance_aggregation.py
@@ -48,4 +48,4 @@ def test_binary_relevance_aggregation_on_toy_data(aggregator: BaseClassification
 def test_binary_relevance_aggregation_on_empty(aggregator: BaseClassificationAggregator) -> None:
     mb = BinaryRelevance(aggregator)
     result = mb.fit_predict(pd.DataFrame([], columns=['task', 'worker', 'label']))
-    assert_series_equal(pd.Series(dtype=float, name='agg_label'), result)
+    assert_series_equal(pd.Series(dtype=float, name='agg_label'), result, check_index_type=False)


### PR DESCRIPTION
Seems some Pandas update broke the tests. This PR fixes them.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
