### PR TITLE
Add NetEaseCrowd dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+
+* Add [NetEaseCrowd](https://github.com/fuxiAIlab/NetEaseCrowd-Dataset) dataset
+  * A multi-class classification dataset with 6 millions annotations
+
 1.2.1
 -------------------
 * Bug fixes in RASA, HRRASA, and documentation

--- a/crowdkit/datasets/_loaders.py
+++ b/crowdkit/datasets/_loaders.py
@@ -283,11 +283,11 @@ DATA_LOADERS: Dict[
     },
     "netease_crowd": {
         "loader": load_netease_crowd,
-        "description": "NetEaseCrowd(https://github.com/fuxiAIlab/NetEaseCrowd-Dataset)"
+        "description": "NetEaseCrowd(https://github.com/fuxiAIlab/NetEaseCrowd-Dataset) "
         "is a large-scale crowdsourcing annotation dataset based on a mature Chinese data "
         "crowdsourcing platform of NetEase Inc.. NetEaseCrowd dataset contains about 2,400 workers, "
         "1,000,000 tasks, and 6,000,000 annotations between them, "
-        "where the annotations are collected in about 6 months."
+        "where the annotations are collected in about 6 months. "
         "This dataset is licensed under CC BY-SA 4.0",
     },
     "mscoco": {

--- a/crowdkit/datasets/_loaders.py
+++ b/crowdkit/datasets/_loaders.py
@@ -4,8 +4,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 
-# from ._base import fetch_remote, get_data_dir
-from crowdkit.datasets._base import fetch_remote, get_data_dir
+from ._base import fetch_remote, get_data_dir
 
 
 def _load_dataset(

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -57,6 +57,20 @@ def collect_stats_for_dataset(
             },
         ),
         (
+            "netease_crowd",
+            {
+                "rows": 6016319,
+                "dtypes_labels": {
+                    "worker": np.int64,
+                    "task": np.int64,
+                    "label": np.int64,
+                },
+                "dtypes_gt": np.int64,
+                "name_gt": "true_label",
+                "index_name_gt": "task",
+            },
+        ),
+        (
             "mscoco",
             {
                 "rows": 18000,


### PR DESCRIPTION
<!--- Provide a general summary of your changes here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Dataset info
Adding our open-source dataset, NetEaseCrowd(https://github.com/fuxiAIlab/NetEaseCrowd-Dataset).

>NetEaseCrowd is a large-scale dataset for long-term and online crowdsourcing truth inference, which contains about 2,400 workers, 1,000,000 tasks, and 6,000,000 annotations collected over 6 months. We believe that this dataset could be an invaluable asset to the Toloka/crowd-kit community by providing a new benchmark for crowdsourcing-related research and development.