### PR TITLE
Miscellaneous doc fixes

### DIFF
--- a/crowdkit/aggregation/classification/mace.py
+++ b/crowdkit/aggregation/classification/mace.py
@@ -87,7 +87,7 @@ class MACE(BaseClassificationAggregator):
     The marginal data likelihood is maximized with the Expectation-Maximization algorithm:
     1. **E-step**. Performs `n_restarts` random restarts, and keeps the model with the best marginal data likelihood.
     2. **M-step**. Smooths parameters by adding a fixed value `smoothing` to the fractional counts before normalizing.
-    3. **Variational M-step**. Employs Variational-Bayes (VB) training with symmetric Beta priors on $\theta_j$ and symmetric Dirichlet priors on the strategy parameters $\xi_j.
+    3. **Variational M-step**. Employs Variational-Bayes (VB) training with symmetric Beta priors on $\theta_j$ and symmetric Dirichlet priors on the strategy parameters $\xi_j$.
 
     D. Hovy, T. Berg-Kirkpatrick, A. Vaswani and E. Hovy. Learning Whom to Trust with MACE.
     In *Proceedings of NAACL-HLT*, Atlanta, GA, USA (2013), 1120–1130.
@@ -122,10 +122,10 @@ class MACE(BaseClassificationAggregator):
     """The default noise parameter for the initialization."""
 
     alpha: float = attr.ib(default=0.5)
-    """The prior parameter for the Beta distribution on $\theta_j$."""
+    r"""The prior parameter for the Beta distribution on $\theta_j$."""
 
     beta: float = attr.ib(default=0.5)
-    """The prior parameter for the Beta distribution on $\theta_j$."""
+    r"""The prior parameter for the Beta distribution on $\theta_j$."""
 
     random_state: int = attr.ib(default=0)
     """The state of the random number generator."""

--- a/crowdkit/metrics/data/_classification.py
+++ b/crowdkit/metrics/data/_classification.py
@@ -48,7 +48,7 @@ def consistency(
 ) -> Union[float, "pd.Series[Any]"]:
     """
     Consistency metric: posterior probability of aggregated label given workers skills
-    calculated using the standard Dawid-Skene model.
+    calculated using the specified aggregator.
 
     Args:
         answers (pandas.DataFrame): A data frame containing `task`, `worker` and `label` columns.


### PR DESCRIPTION
I fixed two spots in the doc:
- The Mace aggregator doc had some broken mathematical symbols. (missing `$` and raw strings).
- The Consistency metric's docstring refers to a Dawid-Skene model whereas the aggregator is actually an attribute of the class and can be any `BaseClassificationAggregator`.

If the changes are OK, would you like me to squash the commits ?

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document
- [x] I hereby agree to the terms of either individual CLA available at: https://toloka.ai/legal/cla_individual or corporate CLA available at: https://toloka.ai/legal/cla_corporate, whichever is applicable to me, as it pertains to direct contributions to crowd-kit only
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
